### PR TITLE
Add component tests

### DIFF
--- a/frontend/src/ArticleView.test.jsx
+++ b/frontend/src/ArticleView.test.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import ArticleView from './components/ArticleView.jsx';
+import '@testing-library/jest-dom';
+
+const mockArticles = [
+  {
+    id: '1',
+    title: 'Test Article',
+    author: 'John',
+    publishedDate: '2024-01-01',
+    summary: 'Summary',
+    content: [
+      { title: 'Section', paragraphs: ['Para'] }
+    ],
+    tags: ['t']
+  }
+];
+const originalFetch = global.fetch;
+
+describe('ArticleView', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ articles: mockArticles })
+      })
+    );
+  });
+
+  afterEach(() => {
+    global.fetch.mockClear();
+    global.fetch = originalFetch;
+  });
+
+  it('shows loading then renders article', async () => {
+    render(<ArticleView articleId="1" onBack={() => {}} />);
+    expect(screen.getByText(/Loading article/i)).toBeInTheDocument();
+    await screen.findByText('Test Article');
+    expect(screen.getByText('Test Article')).toBeInTheDocument();
+  });
+
+  it('shows not found for unknown id', async () => {
+    render(<ArticleView articleId="2" onBack={() => {}} />);
+    await screen.findByText(/Article not found/i);
+  });
+
+  it('shows not found when fetch fails', async () => {
+    global.fetch.mockRejectedValueOnce(new Error('fail'));
+    render(<ArticleView articleId="1" onBack={() => {}} />);
+    await screen.findByText(/Article not found/i);
+  });
+});

--- a/frontend/src/DesktopCategoryView.test.jsx
+++ b/frontend/src/DesktopCategoryView.test.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import DesktopCategoryView from './components/DesktopCategoryView.jsx';
+import '@testing-library/jest-dom';
+
+const mockTopic = {
+  title: 'Faith',
+  description: 'Faith desc',
+  categories: [
+    {
+      category_name: 'Belief',
+      category_description: 'Belief desc',
+      scriptures: [
+        { reference: 'Heb 11:1', text: 'Now faith', context_description: 'ctx' }
+      ]
+    },
+    {
+      category_name: 'Trust',
+      category_description: 'Trust desc',
+      scriptures: [
+        { reference: 'Ps 1', text: 'Blessed', context_description: 'ctx2' }
+      ]
+    }
+  ]
+};
+
+describe('DesktopCategoryView', () => {
+  it('renders tabs and scripture content', () => {
+    render(
+      <DesktopCategoryView
+        selectedTopic={mockTopic}
+        activeTab={0}
+        setActiveTab={() => {}}
+      />
+    );
+    expect(screen.getByText('Faith')).toBeInTheDocument();
+    expect(screen.getAllByText('Belief')[0]).toBeInTheDocument();
+    expect(screen.getByText('Heb 11:1')).toBeInTheDocument();
+  });
+
+  it('changes tab on click', () => {
+    const setActiveTab = jest.fn();
+    render(
+      <DesktopCategoryView
+        selectedTopic={mockTopic}
+        activeTab={0}
+        setActiveTab={setActiveTab}
+      />
+    );
+    fireEvent.click(screen.getByText('Trust'));
+    expect(setActiveTab).toHaveBeenCalledWith(1);
+  });
+});

--- a/frontend/src/MobileAccordion.test.jsx
+++ b/frontend/src/MobileAccordion.test.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import MobileAccordion from './components/MobileAccordion.jsx';
+import '@testing-library/jest-dom';
+
+const categories = [
+  {
+    category_name: 'Belief',
+    category_description: 'Belief desc',
+    scriptures: [
+      { reference: 'Heb 11:1', text: 'Now faith', context_description: 'ctx' }
+    ]
+  }
+];
+
+describe('MobileAccordion', () => {
+  it('renders category and toggles content', () => {
+    const { container } = render(
+      <MobileAccordion categories={categories} topicIcon="<svg></svg>" />
+    );
+    expect(screen.getAllByText('Belief')[0]).toBeInTheDocument();
+    const list = container.querySelector('.rmwc-collapsible-list');
+    expect(list.classList.contains('rmwc-collapsible-list--open')).toBe(false);
+    fireEvent.click(screen.getAllByText('Belief')[0]);
+    expect(list.classList.contains('rmwc-collapsible-list--open')).toBe(true);
+  });
+});

--- a/frontend/src/TopicCard.test.jsx
+++ b/frontend/src/TopicCard.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TopicCard from './components/TopicCard.jsx';
+import '@testing-library/jest-dom';
+
+const topic = {
+  title: 'Faith',
+  description: 'Faith desc',
+  icon: '<svg></svg>'
+};
+
+describe('TopicCard', () => {
+  it('renders info and handles click', () => {
+    const onReadMore = jest.fn();
+    render(<TopicCard topic={topic} onReadMore={onReadMore} />);
+    expect(screen.getByText('Faith')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Read More'));
+    expect(onReadMore).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for ArticleView, DesktopCategoryView, MobileAccordion and TopicCard
- test loading and error handling in ArticleView
- test tab switching, collapsible behavior and button click interactions

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f6a1b467483239b3537dd8268e83e