### PR TITLE
Add random scripture feature

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import './App.css'
 import MobileAccordion from './components/MobileAccordion'
 import DesktopCategoryView from './components/DesktopCategoryView'
 import TopicCard from './components/TopicCard'
+import RandomScripture from './components/RandomScripture'
 // RMWC Components
 import {
   TopAppBar,
@@ -186,6 +187,7 @@ function Home({ topics, loading }) {
   console.log('[Home] Rendering Home return', { topics, articles });
   return (
     <>
+      <RandomScripture topics={topics} />
       <Grid style={{ alignItems: 'start', gap: '16px' }}>
         {topics.map((topic) => {
           console.log('[Home] Rendering TopicCard', topic);

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -68,6 +68,7 @@ describe('App UI', () => {
   });
 
   it('renders topics and articles on home', async () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0);
     render(
       <MemoryRouter>
         <App />
@@ -76,8 +77,11 @@ describe('App UI', () => {
 
     // wait for fetches to resolve and content to render
     await screen.findByText('Faith');
-    expect(screen.getByText('Faith')).toBeInTheDocument();
+    await screen.findByText('Hebrews 11:1');
+    expect(screen.getAllByText('Faith')[0]).toBeInTheDocument();
     expect(screen.getByText('Faith Article')).toBeInTheDocument();
+    expect(screen.getByText('Hebrews 11:1')).toBeInTheDocument();
+    Math.random.mockRestore();
   });
 
   it('navigates to topic detail', async () => {

--- a/frontend/src/RandomScripture.test.jsx
+++ b/frontend/src/RandomScripture.test.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import RandomScripture from './components/RandomScripture.jsx';
+import '@testing-library/jest-dom';
+
+const topics = [
+  {
+    title: 'Faith',
+    description: 'Faith desc',
+    categories: [
+      {
+        category_name: 'Belief',
+        category_description: 'Belief desc',
+        scriptures: [
+          { reference: 'Hebrews 11:1', text: 'Now faith is...', context_description: 'Context' }
+        ]
+      }
+    ]
+  }
+];
+
+describe('RandomScripture', () => {
+  it('renders a random scripture section', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    render(<RandomScripture topics={topics} />);
+    expect(screen.getByText('Faith')).toBeInTheDocument();
+    expect(screen.getByText('Belief')).toBeInTheDocument();
+    expect(screen.getByText('Hebrews 11:1')).toBeInTheDocument();
+    Math.random.mockRestore();
+  });
+});

--- a/frontend/src/components/RandomScripture.css
+++ b/frontend/src/components/RandomScripture.css
@@ -1,9 +1,9 @@
 .random-scripture {
-  width: 100%;
   background-color: var(--color-card-bg);
   padding: 16px;
-  margin-bottom: 16px;
-  border-radius: 4px;
+  margin: 0 16px 16px;
+  border-radius: 8px;
+  box-sizing: border-box;
 }
 .random-scripture h2,
 .random-scripture h3 {
@@ -11,4 +11,10 @@
 }
 .random-scripture p {
   margin: 4px 0;
+}
+.random-context {
+  background: #eef4fb;
+  padding: 8px;
+  border-radius: 8px;
+  margin-top: 8px;
 }

--- a/frontend/src/components/RandomScripture.css
+++ b/frontend/src/components/RandomScripture.css
@@ -13,7 +13,7 @@
   margin: 4px 0;
 }
 .random-context {
-  background: #eef4fb;
+  background: #dde6f1;
   padding: 8px;
   border-radius: 8px;
   margin-top: 8px;

--- a/frontend/src/components/RandomScripture.css
+++ b/frontend/src/components/RandomScripture.css
@@ -1,0 +1,14 @@
+.random-scripture {
+  width: 100%;
+  background-color: var(--color-card-bg);
+  padding: 16px;
+  margin-bottom: 16px;
+  border-radius: 4px;
+}
+.random-scripture h2,
+.random-scripture h3 {
+  margin: 0 0 8px;
+}
+.random-scripture p {
+  margin: 4px 0;
+}

--- a/frontend/src/components/RandomScripture.jsx
+++ b/frontend/src/components/RandomScripture.jsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import './RandomScripture.css';
+
+export default function RandomScripture({ topics }) {
+  const [entry, setEntry] = useState(null);
+
+  useEffect(() => {
+    if (!topics || topics.length === 0) return;
+    const topic = topics[Math.floor(Math.random() * topics.length)];
+    if (!topic.categories || topic.categories.length === 0) return;
+    const category = topic.categories[Math.floor(Math.random() * topic.categories.length)];
+    if (!category.scriptures || category.scriptures.length === 0) return;
+    const scripture = category.scriptures[Math.floor(Math.random() * category.scriptures.length)];
+    setEntry({ topic, category, scripture });
+  }, [topics]);
+
+  if (!entry) return null;
+
+  return (
+    <div className="random-scripture">
+      <h2 className="random-topic-title">{entry.topic.title}</h2>
+      <p className="random-topic-desc">{entry.topic.description}</p>
+      <h3 className="random-category-title">{entry.category.category_name}</h3>
+      <p className="random-category-desc">{entry.category.category_description}</p>
+      <div className="random-scripture-text">
+        <strong>{entry.scripture.reference}</strong>
+        <p className="random-verse">{entry.scripture.text}</p>
+        <p className="random-context">{entry.scripture.context_description}</p>
+      </div>
+    </div>
+  );
+}
+
+RandomScripture.propTypes = {
+  topics: PropTypes.array.isRequired
+};


### PR DESCRIPTION
## Summary
- add `RandomScripture` component with styling
- show a random topic, category and verse on the home page
- test the new component and update the home page test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840c65d6b048323b56e30d93d07d3e6