### PR TITLE
Add color theme switcher with dark mode

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -20,6 +20,14 @@
   --color-dark-text: #ffffff;
   --color-light-bg: #ffffff;
   --color-light-text: #213547;
+  /* Base page colors */
+  --color-bg: var(--color-light-bg);
+  --color-text: var(--color-light-text);
+  /* Theme palette options */
+  --color-option-1: var(--color-lapis);
+  --color-option-2: var(--color-mauve);
+  --color-option-3: var(--color-steel-blue);
+  --color-scheme: light;
 }
 
 #root {
@@ -122,4 +130,28 @@
 .tab.active {
   border-color: var(--color-tab-active);
   font-weight: bold;
+}
+
+/* Theme classes using palette variables */
+body.theme1 {
+  --color-primary: var(--color-option-1);
+}
+body.theme2 {
+  --color-primary: var(--color-option-2);
+}
+body.theme3 {
+  --color-primary: var(--color-option-3);
+}
+body.dark {
+  --color-bg: var(--color-dark-bg);
+  --color-text: var(--color-dark-text);
+  --color-card-bg: #303030;
+  --color-scheme: dark;
+}
+
+/* Color switcher layout */
+.color-switcher {
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -12,7 +12,7 @@
 /* CSS Color Palette */
 :root {
   --color-primary: var(--color-lapis);
-  --color-primary-hover: #535bf2;
+  --color-primary-hover: var(--color-hover-option-1); /* default for option 1 */
   --color-tab-active: #0d47a1;
   --color-card-bg: #f2f5f8;
   --color-text-secondary: #5c71c5;
@@ -27,6 +27,9 @@
   --color-option-1: var(--color-lapis);
   --color-option-2: var(--color-mauve);
   --color-option-3: var(--color-steel-blue);
+  --color-hover-option-1: #5383a1;
+  --color-hover-option-2: #e8d5ff;
+  --color-hover-option-3: #6ba4d2;
   --color-scheme: light;
 }
 
@@ -135,12 +138,15 @@
 /* Theme classes using palette variables */
 body.theme1 {
   --color-primary: var(--color-option-1);
+  --color-primary-hover: var(--color-hover-option-1);
 }
 body.theme2 {
   --color-primary: var(--color-option-2);
+  --color-primary-hover: var(--color-hover-option-2);
 }
 body.theme3 {
   --color-primary: var(--color-option-3);
+  --color-primary-hover: var(--color-hover-option-3);
 }
 body.dark {
   --color-bg: var(--color-dark-bg);

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -31,6 +31,11 @@
   --color-hover-option-2: #e8d5ff;
   --color-hover-option-3: #6ba4d2;
   --color-scheme: light;
+  /* Material theme variables for RMWC */
+  --mdc-theme-background: var(--color-bg);
+  --mdc-theme-surface: var(--color-bg);
+  --mdc-theme-on-surface: var(--color-text);
+  --mdc-theme-text-primary-on-background: var(--color-text);
 }
 
 #root {
@@ -153,6 +158,11 @@ body.dark {
   --color-text: var(--color-dark-text);
   --color-card-bg: #303030;
   --color-scheme: dark;
+  /* Override RMWC surface variables for dark mode */
+  --mdc-theme-background: var(--color-bg);
+  --mdc-theme-surface: var(--color-bg);
+  --mdc-theme-on-surface: var(--color-text);
+  --mdc-theme-text-primary-on-background: var(--color-text);
 }
 
 /* Color switcher layout */

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import MobileAccordion from './components/MobileAccordion'
 import DesktopCategoryView from './components/DesktopCategoryView'
 import TopicCard from './components/TopicCard'
 import RandomScripture from './components/RandomScripture'
+import ColorSwitcher from './components/ColorSwitcher'
 // RMWC Components
 import {
   TopAppBar,
@@ -107,6 +108,9 @@ function App() {
                 </span>
                 Deep Bible
               </TopAppBarTitle>
+            </TopAppBarSection>
+            <TopAppBarSection alignEnd>
+              <ColorSwitcher />
             </TopAppBarSection>
           </TopAppBarRow>
         </TopAppBar>

--- a/frontend/src/ColorSwitcher.test.jsx
+++ b/frontend/src/ColorSwitcher.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ColorSwitcher from './components/ColorSwitcher.jsx';
+import '@testing-library/jest-dom';
+
+afterEach(() => {
+  document.body.className = '';
+  localStorage.clear();
+});
+
+describe('ColorSwitcher', () => {
+  it('changes theme and dark mode', () => {
+    render(<ColorSwitcher />);
+    fireEvent.change(screen.getByLabelText('color select'), { target: { value: 'theme2' } });
+    expect(document.body.classList.contains('theme2')).toBe(true);
+    const checkbox = screen.getByRole('checkbox');
+    fireEvent.click(checkbox);
+    expect(document.body.classList.contains('dark')).toBe(true);
+  });
+});

--- a/frontend/src/components/ColorSwitcher.jsx
+++ b/frontend/src/components/ColorSwitcher.jsx
@@ -1,0 +1,34 @@
+import React, { useState, useEffect } from 'react';
+
+export default function ColorSwitcher() {
+  const [theme, setTheme] = useState(() => localStorage.getItem('theme') || 'theme1');
+  const [dark, setDark] = useState(() => localStorage.getItem('dark') === 'true');
+
+  useEffect(() => {
+    document.body.classList.remove('theme1', 'theme2', 'theme3');
+    document.body.classList.add(theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  useEffect(() => {
+    document.body.classList.toggle('dark', dark);
+    localStorage.setItem('dark', dark);
+  }, [dark]);
+
+  return (
+    <div className="color-switcher">
+      <select value={theme} onChange={e => setTheme(e.target.value)} aria-label="color select">
+        <option value="theme1">Option 1</option>
+        <option value="theme2">Option 2</option>
+        <option value="theme3">Option 3</option>
+      </select>
+      <label>
+        <input
+          type="checkbox"
+          checked={dark}
+          onChange={e => setDark(e.target.checked)}
+        />{' '}Dark
+      </label>
+    </div>
+  );
+}

--- a/frontend/src/components/ColorSwitcher.jsx
+++ b/frontend/src/components/ColorSwitcher.jsx
@@ -25,6 +25,7 @@ export default function ColorSwitcher() {
       <label>
         <input
           type="checkbox"
+          aria-label="dark mode toggle"
           checked={dark}
           onChange={e => setDark(e.target.checked)}
         />{' '}Dark

--- a/frontend/src/components/MobileAccordion.css
+++ b/frontend/src/components/MobileAccordion.css
@@ -19,5 +19,5 @@
   top: 0px;
   z-index: 4;
   /* Ensure header background covers content behind */
-  background: var(--color-light-bg);
+  background: var(--color-bg);
 }

--- a/frontend/src/components/RandomScripture.css
+++ b/frontend/src/components/RandomScripture.css
@@ -13,8 +13,9 @@
   margin: 4px 0;
 }
 .random-context {
-  background: #dde6f1;
+  background: var(--color-card-bg);
   padding: 8px;
   border-radius: 8px;
   margin-top: 8px;
+  color: var(--color-text);
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -49,12 +49,13 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: var(--color-primary);
+  color: var(--color-dark-text);
   cursor: pointer;
   transition: border-color 0.25s;
 }
 button:hover {
-  border-color: var(--color-primary);
+  border-color: var(--color-primary-hover);
 }
 button:focus,
 button:focus-visible {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,9 +3,9 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color-scheme: var(--color-scheme);
+  color: var(--color-text);
+  background-color: var(--color-bg);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -21,11 +21,11 @@ html, body, #root {
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: var(--color-primary);
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: var(--color-primary-hover);
 }
 
 body {
@@ -33,6 +33,8 @@ body {
   padding: 0;
   min-width: 320px;
   /* Removed flex centering for full-width layout */
+  color: var(--color-text);
+  background-color: var(--color-bg);
 }
 
 h1 {
@@ -52,22 +54,10 @@ button {
   transition: border-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  border-color: var(--color-primary);
 }
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,5 +1,12 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+
+// Apply saved theme classes before React renders
+const savedTheme = localStorage.getItem('theme') || 'theme1'
+document.body.classList.add(savedTheme)
+if (localStorage.getItem('dark') === 'true') {
+  document.body.classList.add('dark')
+}
 import './index.css'
 // Import RMWC base styles for Material Design Web Components
 import 'rmwc/styles'


### PR DESCRIPTION
## Summary
- add theme palette variables
- use palette across base styles
- implement `ColorSwitcher` component
- include color switcher in the top app bar
- test theme changes with new unit test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68462a4c393c83239924554df1f892f3