### PR TITLE
Update color palette and picker

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,22 +1,21 @@
 /* 1. Define your palette variables (from main.png & detail.png) */
 :root {
   /* Raw palette */
-  --color-dim-gray:     #686868;   /* Dim gray */
-  --color-mauve:        #C2AFF0;   /* Mauve */
-  --color-indigo:       #9191E9;   /* Tropical indigo */
-  --color-steel-blue:   #457EAC;   /* Steel blue */
-  --color-lapis:        #2D5D7B;   /* Lapis Lazuli */
+  --color-orange:       #FF7A10;
+  --color-green:        #03CA3C;
+  --color-teal:         #6AB991;
+  --color-yellow:       #FFB603;
+  --color-dark-gray:    #393B3D;
 
 }
 
 /* CSS Color Palette */
 :root {
-  --color-primary: var(--color-lapis);
+  --color-primary: var(--color-option-1);
   --color-primary-hover: var(--color-hover-option-1); /* default for option 1 */
   --color-tab-active: #0d47a1;
   --color-card-bg: #f2f5f8;
   --color-text-secondary: #5c71c5;
-  --color-dark-bg: #242424;
   --color-dark-text: #ffffff;
   --color-light-bg: #ffffff;
   --color-light-text: #213547;
@@ -24,12 +23,16 @@
   --color-bg: var(--color-light-bg);
   --color-text: var(--color-light-text);
   /* Theme palette options */
-  --color-option-1: var(--color-lapis);
-  --color-option-2: var(--color-mauve);
-  --color-option-3: var(--color-steel-blue);
-  --color-hover-option-1: #5383a1;
-  --color-hover-option-2: #e8d5ff;
-  --color-hover-option-3: #6ba4d2;
+  --color-option-1: var(--color-orange);
+  --color-option-2: var(--color-green);
+  --color-option-3: var(--color-teal);
+  --color-option-4: var(--color-yellow);
+  --color-option-5: var(--color-dark-gray);
+  --color-hover-option-1: #ffa74a;
+  --color-hover-option-2: #36d55e;
+  --color-hover-option-3: #8fd1b2;
+  --color-hover-option-4: #ffd24d;
+  --color-hover-option-5: #4d4f53;
   --color-scheme: light;
   /* Material theme variables for RMWC */
   --mdc-theme-background: var(--color-bg);
@@ -154,12 +157,17 @@ body.theme3 {
   --color-primary: var(--color-option-3);
   --color-primary-hover: var(--color-hover-option-3);
 }
-body.dark {
-  --color-bg: var(--color-dark-bg);
-  --color-text: var(--color-dark-text);
+body.theme4 {
+  --color-primary: var(--color-option-4);
+  --color-primary-hover: var(--color-hover-option-4);
+}
+body.theme5 {
+  --color-primary: var(--color-option-5);
+  --color-primary-hover: var(--color-hover-option-5);
+  --color-bg: var(--color-dark-gray);
+  --color-text: #ffffff;
   --color-card-bg: #303030;
   --color-scheme: dark;
-  /* Override RMWC surface variables for dark mode */
   --mdc-theme-background: var(--color-bg);
   --mdc-theme-surface: var(--color-bg);
   --mdc-theme-on-surface: var(--color-text);

--- a/frontend/src/ColorSwitcher.test.jsx
+++ b/frontend/src/ColorSwitcher.test.jsx
@@ -9,12 +9,10 @@ afterEach(() => {
 });
 
 describe('ColorSwitcher', () => {
-  it('changes theme and dark mode', () => {
+  it('changes theme when a swatch is clicked', () => {
     render(<ColorSwitcher />);
-    fireEvent.change(screen.getByLabelText('color select'), { target: { value: 'theme2' } });
+    const buttons = screen.getAllByRole('button');
+    fireEvent.click(buttons[1]);
     expect(document.body.classList.contains('theme2')).toBe(true);
-    const checkbox = screen.getByRole('checkbox');
-    fireEvent.click(checkbox);
-    expect(document.body.classList.contains('dark')).toBe(true);
   });
 });

--- a/frontend/src/components/ColorSwitcher.jsx
+++ b/frontend/src/components/ColorSwitcher.jsx
@@ -1,35 +1,34 @@
 import React, { useState, useEffect } from 'react';
 
+const themes = ['theme1', 'theme2', 'theme3', 'theme4', 'theme5'];
+
 export default function ColorSwitcher() {
   const [theme, setTheme] = useState(() => localStorage.getItem('theme') || 'theme1');
-  const [dark, setDark] = useState(() => localStorage.getItem('dark') === 'true');
 
   useEffect(() => {
-    document.body.classList.remove('theme1', 'theme2', 'theme3');
+    document.body.classList.remove(...themes);
     document.body.classList.add(theme);
     localStorage.setItem('theme', theme);
   }, [theme]);
 
-  useEffect(() => {
-    document.body.classList.toggle('dark', dark);
-    localStorage.setItem('dark', dark);
-  }, [dark]);
-
   return (
     <div className="color-switcher">
-      <select value={theme} onChange={e => setTheme(e.target.value)} aria-label="color select">
-        <option value="theme1">Option 1</option>
-        <option value="theme2">Option 2</option>
-        <option value="theme3">Option 3</option>
-      </select>
-      <label>
-        <input
-          type="checkbox"
-          aria-label="dark mode toggle"
-          checked={dark}
-          onChange={e => setDark(e.target.checked)}
-        />{' '}Dark
-      </label>
+      {themes.map(t => (
+        <button
+          key={t}
+          type="button"
+          aria-label={`set ${t}`}
+          onClick={() => setTheme(t)}
+          style={{
+            backgroundColor: `var(--color-${t})`,
+            width: '20px',
+            height: '20px',
+            borderRadius: '50%',
+            border: theme === t ? '2px solid #000' : '1px solid #ccc',
+            cursor: 'pointer'
+          }}
+        />
+      ))}
     </div>
   );
 }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,9 +4,6 @@ import { createRoot } from 'react-dom/client'
 // Apply saved theme classes before React renders
 const savedTheme = localStorage.getItem('theme') || 'theme1'
 document.body.classList.add(savedTheme)
-if (localStorage.getItem('dark') === 'true') {
-  document.body.classList.add('dark')
-}
 import './index.css'
 // Import RMWC base styles for Material Design Web Components
 import 'rmwc/styles'


### PR DESCRIPTION
## Summary
- implement new color palette variables
- replace color switcher dropdown with swatch buttons
- remove separate dark mode toggle
- adjust styles and tests for new theme handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68470f14fc2c8323ad138b3128b1c20e